### PR TITLE
Fix an issue with hashes that begin with numbers.

### DIFF
--- a/updateable/static/updateable.js
+++ b/updateable/static/updateable.js
@@ -24,7 +24,7 @@
       for(var i = 0; i < updateables.length; i++) {
         var updateable = updateables[i];
         var id = updateable.getAttribute('data-updateable');
-        var updated = fragment.querySelector('[data-updateable=' + id + ']');
+        var updated = fragment.querySelector('[data-updateable="' + id + '"]');
         if(updated) {
           updateable.parentNode.replaceChild(updated, updateable);
           settings.callback.call(updated);


### PR DESCRIPTION
  Issue reproduces with chrome 35.0.1916.153 m as a

Uncaught SyntaxError: Failed to execute 'querySelector' on 'DocumentFragment': '[data-updateable=43ec914ed514fc3cae46e7e4f89dae0c]' is not a valid selector. updateable.js:27
readyStateChanged

Putting the id in quotes seems to fix the issue.
