### PR TITLE
include current querystring in request params

### DIFF
--- a/updateable/static/updateable.js
+++ b/updateable/static/updateable.js
@@ -35,7 +35,8 @@
   };
 
   var update = function() {
-    var url = '?' + encodeURI(settings.getVariable + '=true');
+    var currUrlParams = new URLSearchParams(window.location.search).toString();
+    var url = '?' + currUrlParams + '&' + encodeURI(settings.getVariable + '=true');
     var updateables = getUpdateables();
     for(var i = 0; i < updateables.length; i++) {
       var updateable = updateables[i];


### PR DESCRIPTION
Necessary if you pass arguments that way. For example, if you wish to request your data to be sorted.